### PR TITLE
feat: link to DeepWiki

### DIFF
--- a/deepwiki.js
+++ b/deepwiki.js
@@ -1,0 +1,34 @@
+(function () {
+  const pathParts = window.location.pathname.split("/").filter(Boolean);
+  if (pathParts.length < 2) return;
+
+  const [owner, repo] = pathParts;
+  const headerSelector = "ul.UnderlineNav-body.list-style-none";
+  const ul = document.querySelector(headerSelector);
+  if (!ul) return;
+
+  const li = document.createElement("li");
+  li.className = "d-inline-flex";
+
+  const a = document.createElement("a");
+  a.textContent = "";
+  a.href = `https://deepwiki.com/${owner}/${repo}`;
+  a.target = "_blank";
+  a.className =
+    "UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item";
+
+  const img = document.createElement("img");
+  img.src = "https://deepwiki.com/favicon.ico";
+  img.alt = "Deepwiki";
+  img.style.width = "16px";
+  img.style.height = "16px";
+  img.style.verticalAlign = "middle";
+  a.appendChild(img);
+
+  const span = document.createElement("span");
+  span.textContent = "Deepwiki";
+  a.appendChild(span);
+
+  li.appendChild(a);
+  ul.appendChild(li);
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -6,20 +6,17 @@
   "manifest_version": 3,
   "content_scripts": [
     {
-      "matches": [
-        "https://github.com/*/*"
-      ],
-      "css": [
-        "style.css"
-      ]
+      "matches": ["https://github.com/*/*"],
+      "css": ["style.css"]
     },
     {
-      "matches": [
-        "https://github.com/*/*/actions/runs/*"
-      ],
-      "css": [
-        "actions_runs.css"
-      ]
+      "matches": ["https://github.com/*/*/actions/runs/*"],
+      "css": ["actions_runs.css"]
+    },
+    {
+      "matches": ["https://github.com/*/*"],
+      "js": ["deepwiki.js"],
+      "run_at": "document_idle"
     }
   ]
 }


### PR DESCRIPTION
- [DeepWiki | AI documentation you can talk to, for every repo](https://deepwiki.com/)

What is DeepWiki?

> DeepWiki provides up-to-date documentation you can talk to, for every repo in the world. Think Deep Research for GitHub.

というわけで、github.com のリポジトリの URL を deepwiki.com にするだけでドキュメントを生成してくれる。

いちいち書き換えるのが面倒なので、ヘッダのメニューにリンクを追加してアクセスを楽にしてみる。