### PR TITLE
fix: iconの位置調整

### DIFF
--- a/deepwiki.js
+++ b/deepwiki.js
@@ -23,6 +23,7 @@
   img.style.width = "16px";
   img.style.height = "16px";
   img.style.verticalAlign = "middle";
+  img.style.marginRight = "8px";
   a.appendChild(img);
 
   const span = document.createElement("span");


### PR DESCRIPTION
iconの位置がちょっと気になったので他のタブのmarginと揃える

## before
![CleanShot 2025-05-16 at 13 15 47](https://github.com/user-attachments/assets/2c8978e2-3a10-46d2-9353-97dcde943b4f)


## after
![CleanShot 2025-05-16 at 13 14 59](https://github.com/user-attachments/assets/9e02e1e6-80f8-47d9-84f8-e3576f5ef376)
