### PR TITLE
feat: add Deepwiki navigation item with error handling for favicon

### DIFF
--- a/deepwiki.js
+++ b/deepwiki.js
@@ -1,35 +1,52 @@
 (function () {
-  const pathParts = window.location.pathname.split("/").filter(Boolean);
-  if (pathParts.length < 2) return;
+  function addDeepwikiNav() {
+    const pathParts = window.location.pathname.split("/").filter(Boolean);
+    if (pathParts.length < 2) return;
 
-  const [owner, repo] = pathParts;
-  const headerSelector = "ul.UnderlineNav-body.list-style-none";
-  const ul = document.querySelector(headerSelector);
-  if (!ul) return;
+    const [owner, repo] = pathParts;
+    const headerSelector = "ul.UnderlineNav-body.list-style-none";
+    const ul = document.querySelector(headerSelector);
+    if (!ul) return;
 
-  const li = document.createElement("li");
-  li.className = "d-inline-flex";
+    // すでに追加済みなら何もしない
+    if (ul.querySelector('.deepwiki-nav-item')) return;
 
-  const a = document.createElement("a");
-  a.textContent = "";
-  a.href = `https://deepwiki.com/${owner}/${repo}`;
-  a.target = "_blank";
-  a.className =
-    "UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item";
+    const li = document.createElement("li");
+    li.className = "d-inline-flex deepwiki-nav-item";
 
-  const img = document.createElement("img");
-  img.src = "https://deepwiki.com/favicon.ico";
-  img.alt = "Deepwiki";
-  img.style.width = "16px";
-  img.style.height = "16px";
-  img.style.verticalAlign = "middle";
-  img.style.marginRight = "8px";
-  a.appendChild(img);
+    const a = document.createElement("a");
+    a.href = `https://deepwiki.com/${owner}/${repo}`;
+    a.target = "_blank";
+    a.className =
+      "UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item";
 
-  const span = document.createElement("span");
-  span.textContent = "Deepwiki";
-  a.appendChild(span);
+    const img = document.createElement("img");
+    img.src = "https://deepwiki.com/favicon.ico";
+    img.alt = "Deepwiki";
+    img.style.width = "16px";
+    img.style.height = "16px";
+    img.style.verticalAlign = "middle";
+    img.style.marginRight = "8px";
+    img.onerror = function () {
+      this.src =
+        'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="%23007acc" viewBox="0 0 16 16"><rect width="14" height="12" x="1" y="2" rx="2" fill="%23fff" stroke="%23007acc" stroke-width="1.5"/><path d="M4 5h8M4 8h8M4 11h5" stroke="%23007acc" stroke-width="1.2" stroke-linecap="round"/></svg>';
+    };
+    a.appendChild(img);
 
-  li.appendChild(a);
-  ul.appendChild(li);
+    const span = document.createElement("span");
+    span.textContent = "Deepwiki";
+    a.appendChild(span);
+
+    li.appendChild(a);
+    ul.appendChild(li);
+  }
+
+  // Turbo.js対応: turbo:loadイベントで実行
+  document.addEventListener('turbo:load', addDeepwikiNav);
+  // 通常のページロードにも対応
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', addDeepwikiNav);
+  } else {
+    addDeepwikiNav();
+  }
 })();


### PR DESCRIPTION
出先の環境だと、初回アクセス時にアイコンが出ない不具合が発生したのを解消。

- GitHubのContent Security Policy (CSP)により外部サイト（deepwiki.com）のfaviconが読み込めず、コンソールエラーが発生していた問題に対応しました。
- faviconの読み込みに失敗した場合、SVG形式の代替アイコンを表示するようにimg要素のonerrorハンドラを追加しました。これによりCSP制限下でもアイコンが必ず表示されるようになります。
- Turbo.js（turbo:load）イベントや通常のDOMContentLoadedイベントの両方に対応し、ページ遷移やキャッシュ時にもDeepwikiナビゲーションが正しく追加されるようにしました。
- すでにDeepwikiナビゲーションが追加されている場合は重複して追加しないように判定処理を強化しました。

これらの修正により、GitHubリポジトリページでDeepwikiリンクのアイコンが安定して表示され、ページ遷移時のエラーも回避できるようになりました。