### PR TITLE
feat: PR の画面の横幅制限を緩和する

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,10 @@
       "matches": ["https://github.com/*/*"],
       "js": ["deepwiki.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://github.com/*/*/pull/*"],
+      "css": ["pull.css"]
     }
   ]
 }

--- a/pull.css
+++ b/pull.css
@@ -1,0 +1,8 @@
+
+/**
+* max-width restrictions in pull view
+*/
+#repo-content-pjax-container > div
+{
+  max-width: 1600px !important;
+}


### PR DESCRIPTION
PR の CI 等の結果のチェックリストのタイトルが長すぎて通常だと見切れてしまうのを回避するために 横幅の制限を緩和してみる。

具体的には HCP Terraform が走った時に処理結果が一度に見えるようにしたかった。