### PR TITLE
Fix: Ensure CSS is applied consistently on initial page load and transitions

### DIFF
--- a/deepwiki.js
+++ b/deepwiki.js
@@ -41,15 +41,6 @@
     ul.appendChild(li);
   }
 
-  // 初回ロード + turbo.js に対応
-  document.addEventListener("turbo:load", addDeepwikiNav);
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", addDeepwikiNav);
-  } else {
-    addDeepwikiNav();
-    updatePageTypeClass();
-  }
-
   function updatePageTypeClass() {
     const path = location.pathname;
 
@@ -75,13 +66,27 @@
     }
   }
 
+  function handlePageLoadOrTransition() {
+    addDeepwikiNav();
+    updatePageTypeClass();
+  }
+
+  // 初回ロード + turbo.js に対応
+  document.addEventListener("turbo:load", handlePageLoadOrTransition);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", handlePageLoadOrTransition);
+  } else {
+    handlePageLoadOrTransition();
+  }
+
   // URL 変化の検出による SPA 対応
   let lastUrl = location.href;
   const observer = new MutationObserver(() => {
     const currentUrl = location.href;
     if (currentUrl !== lastUrl) {
       lastUrl = currentUrl;
-      setTimeout(addDeepwikiNav, 300); // DOM 安定後に実行
+      // DOM 安定後に実行 (ensure functions run after new page content is likely settled)
+      setTimeout(handlePageLoadOrTransition, 300);
     }
   });
   observer.observe(document.body, { childList: true, subtree: true });


### PR DESCRIPTION
The CSS rules were not always applied on the initial page load or during SPA-like transitions within GitHub. This was because the body classes (e.g., `is-pull-request`, `is-code-file`), which the CSS selectors depend on, were not consistently added by the `updatePageTypeClass()` JavaScript function.

This commit addresses the issue by:
1. Creating a new helper function `handlePageLoadOrTransition` in `deepwiki.js` that calls both `addDeepwikiNav()` (for adding the Deepwiki navigation link) and `updatePageTypeClass()` (for adding the necessary body classes).
2. Ensuring `handlePageLoadOrTransition()` is consistently called during:
    - Initial page load (`DOMContentLoaded` or direct execution if already loaded)
    - GitHub's Turbo Drive navigations (`turbo:load` event)
    - URL changes detected by the `MutationObserver` (for other SPA-like transitions)

This ensures that the required body classes are present when the CSS is expected to be applied, resolving the inconsistent styling behavior.