### PR TITLE
Feature/remove ci prefix

### DIFF
--- a/deepwiki.js
+++ b/deepwiki.js
@@ -72,31 +72,19 @@
   function handlePageLoadOrTransition() {
     addDeepwikiNav();
     updatePageTypeClass();
-    removeCiPrefix(); // Added call
+    removeCiPrefix();
   }
 
   function removeCiPrefix() {
-    const regex = new RegExp("^Terraform Cloud\/[^/]+\/"); // Matches "Terraform Cloud/project_name/"
-    // Selector for CI check titles. This might need adjustment based on GitHub's actual DOM structure.
-    // Common selectors for check names:
-    // 1. `a.Link--primary[href*="/checks/"] > strong` (for links to check details)
-    // 2. `div.merge-status-item .text-emphasized strong` (for status items in PR merge box - often includes the check name)
-    // 3. `span.status-heading strong` (another common pattern for headings that might contain check names)
-    // We'll try a combination or a more general approach if needed.
-    // Let's start with a potentially common one for PR check lists or summaries.
-    const ciCheckTitleSelectors = [
-      'a.Link--primary[href*="/checks/"] > strong', // Links to check details pages
-      '.merge-status-item .text-emphasized', // Status items in PR merge box (often the check name itself)
-      // Consider adding more selectors if the above are not comprehensive
-      // e.g., 'span.text-emphasized[data-testid="check-run-name"]' if such specific attributes exist
-      'div.TimelineItem div.TimelineItem-body div.Box--condensed div.css-truncate.css-truncate-target > strong' // CI check titles in the timeline/conversation view
-    ];
+    const regex = new RegExp("Terraform Cloud/[^/]+/"); // Matches "Terraform Cloud/project_name/"
+    const ciCheckTitleSelectors = ["div.TimelineItem strong"];
 
-    ciCheckTitleSelectors.forEach(selector => {
+    ciCheckTitleSelectors.forEach((selector) => {
       const elements = document.querySelectorAll(selector);
+      console.log(`Removing CI prefix from elements matching: ${selector}`);
       elements.forEach((el) => {
         if (el.textContent && regex.test(el.textContent)) {
-          el.textContent = el.textContent.replace(regex, ""); // Replace using regex
+          el.textContent = el.textContent.replace(regex, "");
         }
       });
     });
@@ -116,34 +104,22 @@
     const currentUrl = location.href;
     if (currentUrl !== lastUrl) {
       lastUrl = currentUrl;
-      // DOM 安定後に実行 (ensure functions run after new page content is likely settled)
-      // handlePageLoadOrTransition already calls removeCiPrefix
       setTimeout(handlePageLoadOrTransition, 300);
     } else {
-      // For dynamic content changes on the same page (e.g., CI status updates)
-      // Debounce the call to removeCiPrefix
       clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(removeCiPrefix, 150); // Use a shorter timeout for same-page updates
+      debounceTimer = setTimeout(removeCiPrefix, 150);
     }
   });
   observer.observe(document.body, { childList: true, subtree: true });
 
-  document.body.addEventListener('click', function(event) {
-    // Check for "View detail" or "Details" buttons, common in GH CI views
-    // Handles cases where click might be on a child element (e.g., span) inside the button/summary
-    const potentialButton = event.target.closest('button, summary, [role="button"]');
+  document.body.addEventListener("click", function (event) {
+    const potentialButton = event.target.closest(
+      'button, summary, [role="button"]'
+    );
 
     if (potentialButton) {
       const textContent = potentialButton.textContent.toLowerCase();
-      // Check for "detail" or "details" which are common in GH interface for expanding sections
-      if (textContent.includes('detail') || textContent.includes('details')) {
-        // In a future step, we will call removeCiPrefix here, likely after a short delay
-        // to allow the new content (CI job details) to render.
-        // For now, a console log suffices for verification if the environment allowed.
-        // The structure itself is the primary goal for this step.
-        // Call removeCiPrefix after a delay to allow content to load/render
-        setTimeout(removeCiPrefix, 300); // Using 300ms as a reasonable starting delay
-      }
+      setTimeout(removeCiPrefix, 300);
     }
   });
 })();

--- a/deepwiki.js
+++ b/deepwiki.js
@@ -69,6 +69,32 @@
   function handlePageLoadOrTransition() {
     addDeepwikiNav();
     updatePageTypeClass();
+    removeCiPrefix(); // Added call
+  }
+
+  function removeCiPrefix() {
+    // Selector for CI check titles. This might need adjustment based on GitHub's actual DOM structure.
+    // Common selectors for check names:
+    // 1. `a.Link--primary[href*="/checks/"] > strong` (for links to check details)
+    // 2. `div.merge-status-item .text-emphasized strong` (for status items in PR merge box - often includes the check name)
+    // 3. `span.status-heading strong` (another common pattern for headings that might contain check names)
+    // We'll try a combination or a more general approach if needed.
+    // Let's start with a potentially common one for PR check lists or summaries.
+    const ciCheckTitleSelectors = [
+      'a.Link--primary[href*="/checks/"] > strong', // Links to check details pages
+      '.merge-status-item .text-emphasized', // Status items in PR merge box (often the check name itself)
+      // Consider adding more selectors if the above are not comprehensive
+      // e.g., 'span.text-emphasized[data-testid="check-run-name"]' if such specific attributes exist
+    ];
+
+    ciCheckTitleSelectors.forEach(selector => {
+      const elements = document.querySelectorAll(selector);
+      elements.forEach((el) => {
+        if (el.textContent && el.textContent.includes("HCP Terraform/*/")) {
+          el.textContent = el.textContent.replace("HCP Terraform/*/", "");
+        }
+      });
+    });
   }
 
   // 初回ロード + turbo.js に対応
@@ -86,7 +112,10 @@
     if (currentUrl !== lastUrl) {
       lastUrl = currentUrl;
       // DOM 安定後に実行 (ensure functions run after new page content is likely settled)
-      setTimeout(handlePageLoadOrTransition, 300);
+      setTimeout(() => {
+        handlePageLoadOrTransition();
+        removeCiPrefix(); // Explicitly call after handlePageLoadOrTransition as per instructions
+      }, 300);
     }
   });
   observer.observe(document.body, { childList: true, subtree: true });

--- a/deepwiki.js
+++ b/deepwiki.js
@@ -76,6 +76,7 @@
   }
 
   function removeCiPrefix() {
+    const regex = new RegExp("^Terraform Cloud\/[^/]+\/"); // Matches "Terraform Cloud/project_name/"
     // Selector for CI check titles. This might need adjustment based on GitHub's actual DOM structure.
     // Common selectors for check names:
     // 1. `a.Link--primary[href*="/checks/"] > strong` (for links to check details)
@@ -94,9 +95,8 @@
     ciCheckTitleSelectors.forEach(selector => {
       const elements = document.querySelectorAll(selector);
       elements.forEach((el) => {
-        if (el.textContent && el.textContent.includes("Terraform Cloud/*/")) {
-          // Prepend "FIXED: " for diagnostic purposes
-          el.textContent = "FIXED: " + el.textContent.replace("Terraform Cloud/*/", "");
+        if (el.textContent && regex.test(el.textContent)) {
+          el.textContent = el.textContent.replace(regex, ""); // Replace using regex
         }
       });
     });

--- a/deepwiki.js
+++ b/deepwiki.js
@@ -126,4 +126,23 @@
     }
   });
   observer.observe(document.body, { childList: true, subtree: true });
+
+  document.body.addEventListener('click', function(event) {
+    // Check for "View detail" or "Details" buttons, common in GH CI views
+    // Handles cases where click might be on a child element (e.g., span) inside the button/summary
+    const potentialButton = event.target.closest('button, summary, [role="button"]');
+
+    if (potentialButton) {
+      const textContent = potentialButton.textContent.toLowerCase();
+      // Check for "detail" or "details" which are common in GH interface for expanding sections
+      if (textContent.includes('detail') || textContent.includes('details')) {
+        // In a future step, we will call removeCiPrefix here, likely after a short delay
+        // to allow the new content (CI job details) to render.
+        // For now, a console log suffices for verification if the environment allowed.
+        // The structure itself is the primary goal for this step.
+        // Call removeCiPrefix after a delay to allow content to load/render
+        setTimeout(removeCiPrefix, 300); // Using 300ms as a reasonable starting delay
+      }
+    }
+  });
 })();

--- a/deepwiki.js
+++ b/deepwiki.js
@@ -95,7 +95,8 @@
       const elements = document.querySelectorAll(selector);
       elements.forEach((el) => {
         if (el.textContent && el.textContent.includes("Terraform Cloud/*/")) {
-          el.textContent = el.textContent.replace("Terraform Cloud/*/", "");
+          // Prepend "FIXED: " for diagnostic purposes
+          el.textContent = "FIXED: " + el.textContent.replace("Terraform Cloud/*/", "");
         }
       });
     });

--- a/deepwiki.js
+++ b/deepwiki.js
@@ -1,4 +1,7 @@
 (function () {
+  "use strict"; // Assuming 'use strict' might be good practice, or place it where appropriate.
+  let debounceTimer = null;
+
   function addDeepwikiNav() {
     const pathParts = window.location.pathname.split("/").filter(Boolean);
     if (pathParts.length < 2) return;
@@ -113,10 +116,13 @@
     if (currentUrl !== lastUrl) {
       lastUrl = currentUrl;
       // DOM 安定後に実行 (ensure functions run after new page content is likely settled)
-      setTimeout(() => {
-        handlePageLoadOrTransition();
-        removeCiPrefix(); // Explicitly call after handlePageLoadOrTransition as per instructions
-      }, 300);
+      // handlePageLoadOrTransition already calls removeCiPrefix
+      setTimeout(handlePageLoadOrTransition, 300);
+    } else {
+      // For dynamic content changes on the same page (e.g., CI status updates)
+      // Debounce the call to removeCiPrefix
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(removeCiPrefix, 150); // Use a shorter timeout for same-page updates
     }
   });
   observer.observe(document.body, { childList: true, subtree: true });

--- a/deepwiki.js
+++ b/deepwiki.js
@@ -85,13 +85,14 @@
       '.merge-status-item .text-emphasized', // Status items in PR merge box (often the check name itself)
       // Consider adding more selectors if the above are not comprehensive
       // e.g., 'span.text-emphasized[data-testid="check-run-name"]' if such specific attributes exist
+      'div.TimelineItem div.TimelineItem-body div.Box--condensed div.css-truncate.css-truncate-target > strong' // CI check titles in the timeline/conversation view
     ];
 
     ciCheckTitleSelectors.forEach(selector => {
       const elements = document.querySelectorAll(selector);
       elements.forEach((el) => {
-        if (el.textContent && el.textContent.includes("HCP Terraform/*/")) {
-          el.textContent = el.textContent.replace("HCP Terraform/*/", "");
+        if (el.textContent && el.textContent.includes("Terraform Cloud/*/")) {
+          el.textContent = el.textContent.replace("Terraform Cloud/*/", "");
         }
       });
     });


### PR DESCRIPTION
- fix: #15 

HCP Terraform の CI 結果について、タイトル文字列が長すぎて見切れてしまうので `Terraform Cloud/<ORG>/` の部分を削ることにした。
アイコンは見えているしワークスペース名が残り、plan 結果も見えるようになったはず。
そもそも横幅の広いデスクトップ向けの機能拡張だが、ノートPCのような横幅が不足している画面でも多少なりとも見やすくなればと思う。
HCP Terraform に名称変更したんだし、タイトル部分はどうにかならんのか。。。？