### PR TITLE
fix: remove CI title for GitHub EMU

### DIFF
--- a/cosmetic.js
+++ b/cosmetic.js
@@ -77,7 +77,10 @@
 
   function removeCiPrefix() {
     const regex = new RegExp("Terraform Cloud/[^/]+/"); // Matches "Terraform Cloud/project_name/"
-    const ciCheckTitleSelectors = ["div.TimelineItem strong"];
+    const ciCheckTitleSelectors = [
+      "div.TimelineItem strong", // 通常の GitHub
+      "ul li div a span", // GitHub EMU
+    ];
 
     ciCheckTitleSelectors.forEach((selector) => {
       const elements = document.querySelectorAll(selector);


### PR DESCRIPTION
職場の GitHub EMU で CI タイトルの省略がうまく機能していないなって思ったら
HTML の構造が通常の GitHub とは違っていた。。。_np

固定でちょうどいい class が取れない（たぶんビルド時にごにょごにょするやつでついているポストフィックスがある） みたいなので、ベタでマージボックス内のタグ構造で検索することにした。