### PR TITLE
fix: max-width: stretch

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,5 +21,5 @@ body.is-code-file div.container-xl {
  * for pull requests page
 */
 body.is-pull-request #repo-content-pjax-container div {
-  max-width: 1600px !important;
+  max-width: stretch !important;
 }


### PR DESCRIPTION
PR ページで 1600 にしていると、もっと横幅の画面で有効活用できなかったので
画面横幅いっぱいに使えるようにした。

chrome でしか使うのを想定していないので、他のブラウザで動かないのは知らん。