### PR TITLE
Fix narrow review popover window on pull request pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,6 +20,6 @@ body.is-code-file div.container-xl {
  * max-width restrictions in pull view
  * for pull requests page
 */
-body.is-pull-request #repo-content-pjax-container div {
-  max-width: stretch !important;
+body.is-pull-request .container-xl {
+  max-width: initial !important;
 }


### PR DESCRIPTION
Refined the CSS selector for widening pull request pages to target specifically the `.container-xl` class instead of all nested `div` elements. This prevents the "Finish your review" popover (and other nested components) from having their width forced to `stretch`, restoring their standard dimensions while maintaining the wide-screen layout for the main content. Also standardized the property value to `initial` for consistency with other parts of the project.

Fixes #52

---
*PR created automatically by Jules for task [14094332659175617772](https://jules.google.com/task/14094332659175617772) started by @officel*