### PR TITLE
Expand PR main content width

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,6 +20,8 @@ body.is-code-file div.container-xl {
  * max-width restrictions in pull view
  * for pull requests page
 */
-body.is-pull-request .container-xl {
+body.is-pull-request .container-xl,
+body.is-pull-request .PageLayout-content,
+body.is-pull-request .PageLayout {
   max-width: initial !important;
 }


### PR DESCRIPTION
Expand the main content width of GitHub Pull Request pages by targeting modern PageLayout selectors in CSS.

Fixes #57

---
*PR created automatically by Jules for task [7650614774935681376](https://jules.google.com/task/7650614774935681376) started by @officel*