### PR TITLE
Expand Pull Request conversation width

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,6 +24,10 @@ body.is-pull-request .container-xl,
 body.is-pull-request .PageLayout-content,
 body.is-pull-request .PageLayout,
 body.is-pull-request .pull-discussion-timeline,
-body.is-pull-request [data-width="large"] {
+body.is-pull-request [data-width="large"],
+body.is-pull-request div[class*="PageLayout-ContentWrapper"],
+body.is-pull-request div[class*="PageLayout-Content-"],
+body.is-pull-request div[class*="PageLayout-PageLayoutContent"] {
   max-width: initial !important;
+  width: 100% !important;
 }

--- a/style.css
+++ b/style.css
@@ -22,6 +22,8 @@ body.is-code-file div.container-xl {
 */
 body.is-pull-request .container-xl,
 body.is-pull-request .PageLayout-content,
-body.is-pull-request .PageLayout {
+body.is-pull-request .PageLayout,
+body.is-pull-request .pull-discussion-timeline,
+body.is-pull-request [data-width="large"] {
   max-width: initial !important;
 }


### PR DESCRIPTION
The PR conversation timeline on GitHub was restricted to a narrow width even after other parts of the UI were expanded. This change targets the specific CSS classes and attributes used by GitHub to constrain the conversation width (`.pull-discussion-timeline` and `[data-width="large"]`) and removes these restrictions in the context of Pull Requests.

Verification was performed using a mock HTML environment to confirm that the new CSS rules correctly override the default max-widths, allowing the conversation area to expand to the full width of the container.

Fixes #59

---
*PR created automatically by Jules for task [10711297703745638492](https://jules.google.com/task/10711297703745638492) started by @officel*